### PR TITLE
feat: Support Gemini

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.24.3",
+    "@google/generative-ai": "^0.14.1",
     "openai": "^4.52.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@anthropic-ai/sdk':
     specifier: ^0.24.3
     version: 0.24.3
+  '@google/generative-ai':
+    specifier: ^0.14.1
+    version: 0.14.1
   openai:
     specifier: ^4.52.2
     version: 4.52.2
@@ -246,6 +249,11 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@google/generative-ai@0.14.1:
+    resolution: {integrity: sha512-pevEyZCb0Oc+dYNlSberW8oZBm4ofeTD5wN01TowQMhTwdAbGAnJMtQzoklh6Blq2AKsx8Ox6FWa44KioZLZiA==}
+    engines: {node: '>=18.0.0'}
+    dev: false
 
   /@rollup/rollup-android-arm-eabi@4.18.0:
     resolution: {integrity: sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==}

--- a/scripts/example.ts
+++ b/scripts/example.ts
@@ -11,16 +11,18 @@ const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
 ]
 
 const callLLM = async () => {
-  const llm = new LLM({
-    apiKey: process.env.OPENAI_API_KEY
-  })
-
+  const llm = new LLM()
   const result = await llm.chat.completions.create({
+    stream: true,
     messages,
     model: 'gpt-4o'
   })
 
-  console.log(result.choices[0].message.content)
+  // console.log(result.choices[0].message.content)
+
+  for await (const part of result) {
+    process.stdout.write(part.choices[0]?.delta?.content || "");
+  }
 
   // We can also stream and the response type is correctly inferred, uncomment to check
   // const stream = await llm.chat.completions.create({

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -12,11 +12,8 @@ type CompletionBase = Pick<ChatCompletionCreateParamsBase,
   'top_p' | 
   'stop' | 
   'presence_penalty' | 
-  'response_format' | 
   'n' | 
-  'max_tokens' | 
-  'functions' | 
-  'function_call'
+  'max_tokens'
 > & {
   model: LLMChatModel;
 }

--- a/src/handlers/gemini.ts
+++ b/src/handlers/gemini.ts
@@ -1,0 +1,200 @@
+import OpenAI from "openai";
+import { ChatCompletionContentPart } from "openai/resources/index.mjs";
+import { BaseHandler, CompletionResponse, InputError, StreamCompletionResponse } from "./types";
+import { 
+  GoogleGenerativeAI, 
+  Content,
+  Part,
+  GenerativeModel,
+  FinishReason,
+  UsageMetadata
+} from "@google/generative-ai"
+import { getTimestamp } from "./utils";
+import { CompletionParams } from "../chat";
+
+const parseImage = (image: string): { content: string, mimeType: string } => {
+  const parts = image.split(";base64,")
+  if (parts.length === 2) {
+    return {
+      content: parts[1],
+      mimeType: parts[0].replace('data:', '')
+    }
+  } else {
+    throw new InputError("Invalid image URL")
+  }
+}
+
+const convertContentToPart = (content: Array<ChatCompletionContentPart>): Part[] => {
+  if (typeof content === "string") {
+    return [{
+      text: content
+    }]
+  } else {
+    return content.map((part) => {
+      if (part.type === "text") {
+        return {
+          text: part.text
+        }
+      } else if (part.type === "image_url") {
+        const imageData = parseImage(part.image_url.url)
+        return {
+          inlineData: {
+            mimeType: imageData.mimeType,
+            data: imageData.content
+          }
+        }
+      } else {
+        throw new InputError(`Invalid content part type: ${(part as any).type}. Must be "text" or "image_url".`)
+      }
+    })
+  }
+}
+
+const convertMessageToContent  = (message: OpenAI.Chat.Completions.ChatCompletionMessageParam): Content => {
+  if (typeof message.content === "string") {
+    return { 
+      role: message.role,
+      parts: [{
+        text: message.content
+      }]
+    }
+  } else if (Array.isArray(message.content)) {
+    return {
+      role: message.role,
+      parts: convertContentToPart(message.content)
+    }
+  } else {
+    return {
+      role: message.role,
+      parts: []
+    }
+  }
+}
+
+const convertFinishReason = (finishReason: FinishReason): 'stop' | 'length' | 'tool_calls' | 'content_filter' | 'function_call' => {
+  switch (finishReason) {
+    case FinishReason.STOP:
+      return 'stop'
+    case FinishReason.MAX_TOKENS:
+      return 'length'
+    case FinishReason.SAFETY:
+      return 'content_filter'
+    case FinishReason.OTHER:
+    case FinishReason.FINISH_REASON_UNSPECIFIED:
+    case FinishReason.RECITATION:
+      return 'stop'
+    default:
+      return 'stop'
+  }
+}
+
+const fetchResponse = async (
+  model: GenerativeModel,
+  body: CompletionParams
+): Promise<CompletionResponse> => {
+  const timestamp = getTimestamp()
+  const result = await model.generateContent({
+    contents: body.messages.map(convertMessageToContent),
+  })
+
+  return {
+    id: null,
+    object: 'chat.completion',
+    created: timestamp,
+    model: model.model,
+    choices: result.response.candidates?.map((candidate) => {
+      return {
+        index: candidate.index,
+        finish_reason: candidate.finishReason ? convertFinishReason(candidate.finishReason) : 'stop',
+        message: {
+          // Google's format doesn't perfectly fit into OpenAIs format when there are multiple possible results
+          // Namely OpenAI expects the content to be a single string, but Google's API may return multiple objects in the content array
+          // which may be different types (text, image, function call, code execution, etc.)
+          // I chose to handle this for now by just only supporting text and concatenating the results together, but this is definitely
+          // not ideal. A fully custom response format could improve this.
+          content: candidate.content.parts.map((part) => part.text).join(''),
+          role: 'assistant'
+        },
+        // Google does not support logprobs
+        logprobs: null
+        // There are also some other fields that Google returns that are not supported in the OpenAI format such as citations and safety ratings
+      }
+    }) ?? [],
+    usage: result.response.usageMetadata ? convertUsageData(result.response.usageMetadata) : undefined
+  }
+}
+
+const convertUsageData = (usageMetadata: UsageMetadata): CompletionResponse['usage'] => {
+  return {
+    completion_tokens: usageMetadata.candidatesTokenCount,
+    prompt_tokens: usageMetadata.promptTokenCount,
+    total_tokens: usageMetadata.totalTokenCount
+  }
+}
+
+async function* fetchStreamResponse(
+  model: GenerativeModel,
+  body: CompletionParams
+): StreamCompletionResponse {
+  const timestamp = getTimestamp()
+  const result = await model.generateContentStream({
+    contents: body.messages.map(convertMessageToContent)
+  })
+
+  for await (const chunk of result.stream) {
+    const text = chunk.text()
+    yield {
+      id: null,
+      object: 'chat.completion.chunk',
+      created: timestamp,
+      model: model.model,
+      choices: chunk.candidates?.map((candidate) => {
+        return {
+          index: candidate.index,
+          finish_reason: candidate.finishReason ? convertFinishReason(candidate.finishReason) : 'stop',
+          delta: {
+            content: text,
+            role: 'assistant'
+          },
+          logprobs: null
+        }
+      }) ?? [],
+      usage: chunk.usageMetadata ? convertUsageData(chunk.usageMetadata) : undefined
+    }
+  }
+}
+
+
+// To support a new provider, we just create a handler for them extending the BaseHandler class and implement the create method.
+// Then we update the Handlers object in src/handlers/utils.ts to include the new handler.
+export class GeminiHandler extends BaseHandler {
+  async create(
+    body: CompletionParams,
+  ): Promise<CompletionResponse | StreamCompletionResponse> {
+    const apiKey = this.opts.apiKey ?? process.env.GEMINI_API_KEY;
+    if (apiKey === undefined) {
+      throw new InputError("API key is required for Gemini, define GEMINI_API_KEY in your environment or specifty the apiKey option.");
+    }
+
+    const stop = typeof body.stop === 'string' ? [body.stop] : body.stop
+    const genAI = new GoogleGenerativeAI(apiKey)
+    const model = genAI.getGenerativeModel({
+      model: body.model,
+      generationConfig: {
+        maxOutputTokens: body.max_tokens ?? undefined,
+        temperature: body.temperature ?? undefined,
+        topP: body.top_p ?? undefined,
+        stopSequences: stop ?? undefined,
+        candidateCount: body.n ?? undefined,
+      }
+      // Google also supports configurable safety settings which do not fit into the OpenAI format (this was an issue for us in the past, so we'll likely need to address it at some point)
+      // Google also supports cached content which does not fit into the OpenAI format
+    })
+
+    if (body.stream) {
+      return fetchStreamResponse(model, body)
+    } else {
+      return fetchResponse(model, body)
+    }
+  }
+}

--- a/src/handlers/openai.ts
+++ b/src/handlers/openai.ts
@@ -1,17 +1,36 @@
 import OpenAI from "openai";
-import { APIPromise } from "openai/core.mjs";
-import { ChatCompletionChunk, ChatCompletionCreateParams } from "openai/resources/index.mjs";
-import { ChatCompletion } from "openai/src/resources/index.js";
 import { Stream } from "openai/streaming.mjs";
-import { BaseHandler } from "./types";
+import { BaseHandler, CompletionResponse, StreamCompletionResponse } from "./types";
+import { CompletionParams } from "../chat";
+
+async function* streamOpenAI(
+  response: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>
+): StreamCompletionResponse {
+  for await (const chunk of response) {
+    yield chunk
+  }
+}
 
 // To support a new provider, we just create a handler for them extending the BaseHandler class and implement the create method.
 // Then we update the Handlers object in src/handlers/utils.ts to include the new handler.
 export class OpenAIHandler extends BaseHandler {
-  create(
-    body: ChatCompletionCreateParams,
-  ): APIPromise<ChatCompletion | Stream<ChatCompletionChunk>> {
-    const openai = new OpenAI(this.opts);
-    return openai.chat.completions.create(body);
+  async create(
+    body: CompletionParams,
+  ): Promise<CompletionResponse | StreamCompletionResponse> {
+    // Uses the OPENAI_API_KEY environment variable, if the apiKey is not provided.
+    // This makes the UX better for switching between providers because you can just
+    // define all the environment variables and then change the model field without doing anything else.
+    const apiKey = this.opts.apiKey ?? process.env.OPENAI_API_KEY;
+    const openai = new OpenAI({
+      ...this.opts,
+      apiKey,
+    });
+    
+    if (body.stream) {
+      const stream = await openai.chat.completions.create(body)
+      return streamOpenAI(stream);
+    } else {
+      return openai.chat.completions.create(body);
+    }
   }
 }

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -5,11 +5,23 @@ import { ChatCompletion } from "openai/src/resources/index.js";
 import { APIPromise } from "openai/core.mjs";
 import { Stream } from "openai/streaming.mjs";
 
+export type GeminiModels = 'gemini-1.5-pro' | 'gemini-1.5-flash' | 'gemini-1.0-pro'
+
 // We can extend this with additional model names from other providers
-export type LLMChatModel = ChatModel
+export type LLMChatModel = ChatModel | GeminiModels
 
 // We can pick addtional options if we want to extend the configuration
-export type ConfigOptions = Pick<ClientOptions, 'apiKey'>;
+export type ConfigOptions = Pick<ClientOptions, 'apiKey' | 'baseURL'>;
+
+export type CompletionResponseFields = 'choices' | 'created' | 'model' | 'usage' | 'object'
+export type CompletionResponse = Pick<ChatCompletion, CompletionResponseFields> & {
+  id: string | null
+}
+export type CompletionResponseChunk = Pick<ChatCompletionChunk, CompletionResponseFields>  & {
+  id: string | null
+}
+export type StreamCompletionResponse = AsyncIterable<CompletionResponseChunk>
+
 
 // This is the base handler type used to support different providers. We can extend this to support
 // additional features as needed.
@@ -26,5 +38,13 @@ export abstract class BaseHandler {
 
   abstract create(
     body: CompletionParams,
-  ): APIPromise<ChatCompletion | Stream<ChatCompletionChunk>>;
+  ): Promise<CompletionResponse | StreamCompletionResponse>;
+}
+
+export class InputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
 }

--- a/src/handlers/utils.ts
+++ b/src/handlers/utils.ts
@@ -1,8 +1,10 @@
+import { GeminiHandler } from "./gemini";
 import { OpenAIHandler } from "./openai";
 import { ConfigOptions } from "./types";
 
 export const Handlers: Record<string, (opts: ConfigOptions) => any> = {
   'gpt-': (opts: ConfigOptions) => new OpenAIHandler(opts),
+  'gemini-': (opts: ConfigOptions) => new GeminiHandler(opts)
 };
 
 export const getHandler = (modelName: string, opts: ConfigOptions): any => {
@@ -14,3 +16,7 @@ export const getHandler = (modelName: string, opts: ConfigOptions): any => {
 
   throw new Error(`Could not find provider for model. Are you sure the model name is correct and the provider is supported?`);
 };
+
+export const getTimestamp = () => {
+  return Math.floor(new Date().getTime() / 1000)
+}


### PR DESCRIPTION
## Purpose
Adds support for [Gemini API](https://ai.google.dev/?authuser=1) using the [`@google/generative-ai`](https://www.npmjs.com/package/@google/generative-ai) sdk. Note that this does not include support for [Vertex AI](https://cloud.google.com/vertex-ai?hl=en) which uses a [different SDK](https://www.npmjs.com/package/@google-cloud/vertexai). Only Google would do that. I chose to use the Gemini SDK because it's more popular and has a free tier. Maybe at some point we'll want to support Vertex. Or maybe Google will kill it before we have to.