### PR TITLE
poc: Support gemini safety settings with advanced types

### DIFF
--- a/scripts/example.ts
+++ b/scripts/example.ts
@@ -1,6 +1,7 @@
 import { OpenAI } from 'openai';
 import { LLM } from '../src';
 import * as dotenv from 'dotenv';
+import { HarmBlockThreshold, HarmCategory } from '@google/generative-ai';
 dotenv.config();
 
 const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
@@ -14,8 +15,26 @@ const callLLM = async () => {
   const llm = new LLM()
   const result = await llm.chat.completions.create({
     stream: true,
+    model: 'gemini-1.0-pro',
     messages,
-    model: 'gpt-4o'
+    safety_settings: [
+      {
+        category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        threshold: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+      }
+    ]
+  })
+
+  const invalid = await llm.chat.completions.create({
+    stream: true,
+    model: 'gpt-3.5-turbo',
+    messages,
+    safety_settings: [
+      {
+        category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        threshold: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+      }
+    ]
   })
 
   // console.log(result.choices[0].message.content)

--- a/src/handlers/gemini.ts
+++ b/src/handlers/gemini.ts
@@ -10,7 +10,7 @@ import {
   UsageMetadata
 } from "@google/generative-ai"
 import { getTimestamp } from "./utils";
-import { CompletionParams } from "../chat";
+import { CompletionParamsGemini } from "../chat";
 
 const parseImage = (image: string): { content: string, mimeType: string } => {
   const parts = image.split(";base64,")
@@ -90,7 +90,7 @@ const convertFinishReason = (finishReason: FinishReason): 'stop' | 'length' | 't
 
 const fetchResponse = async (
   model: GenerativeModel,
-  body: CompletionParams
+  body: CompletionParamsGemini
 ): Promise<CompletionResponse> => {
   const timestamp = getTimestamp()
   const result = await model.generateContent({
@@ -134,7 +134,7 @@ const convertUsageData = (usageMetadata: UsageMetadata): CompletionResponse['usa
 
 async function* fetchStreamResponse(
   model: GenerativeModel,
-  body: CompletionParams
+  body: CompletionParamsGemini
 ): StreamCompletionResponse {
   const timestamp = getTimestamp()
   const result = await model.generateContentStream({
@@ -169,7 +169,7 @@ async function* fetchStreamResponse(
 // Then we update the Handlers object in src/handlers/utils.ts to include the new handler.
 export class GeminiHandler extends BaseHandler {
   async create(
-    body: CompletionParams,
+    body: CompletionParamsGemini,
   ): Promise<CompletionResponse | StreamCompletionResponse> {
     const apiKey = this.opts.apiKey ?? process.env.GEMINI_API_KEY;
     if (apiKey === undefined) {
@@ -186,7 +186,8 @@ export class GeminiHandler extends BaseHandler {
         topP: body.top_p ?? undefined,
         stopSequences: stop ?? undefined,
         candidateCount: body.n ?? undefined,
-      }
+      },
+      safetySettings: body.safety_settings
       // Google also supports configurable safety settings which do not fit into the OpenAI format (this was an issue for us in the past, so we'll likely need to address it at some point)
       // Google also supports cached content which does not fit into the OpenAI format
     })

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -5,10 +5,11 @@ import { ChatCompletion } from "openai/src/resources/index.js";
 import { APIPromise } from "openai/core.mjs";
 import { Stream } from "openai/streaming.mjs";
 
-export type GeminiModels = 'gemini-1.5-pro' | 'gemini-1.5-flash' | 'gemini-1.0-pro'
+export type GeminiModel = 'gemini-1.5-pro' | 'gemini-1.5-flash' | 'gemini-1.0-pro'
+export type OpenAIModel = ChatModel
 
 // We can extend this with additional model names from other providers
-export type LLMChatModel = ChatModel | GeminiModels
+export type LLMChatModel = ChatModel | GeminiModel
 
 // We can pick addtional options if we want to extend the configuration
 export type ConfigOptions = Pick<ClientOptions, 'apiKey' | 'baseURL'>;


### PR DESCRIPTION
## Purpose
This is an experimental set of changes, it's not really intended to be merged as is. I'm just using this PR as a way to express some product thoughts on how to handle cases where certain SDKs support features that others do not. Including what options we have for handling those cases and in what scenarios they make sense to use.

This PR implements a proof of concept for type discrimination to allow the user to specify safety settings for Gemini models. If you don't know already, type discrimination is basically just using advanced typescript options to have a single function where the exact input types depend on specific input fields. So in our case using type discrimination would mean that if you defined an OpenAI model, then only a certain set of fields would be available to you. If you defined a Gemini model, then you would get a different set of fields. 

I have mixed feels on using type discrimination because I think a design goal of the SDK is to allow the user to easily switch between different model providers. Having certain options immediately cause type errors if you try to switch to a different provider, seems to conflict with that. 

## Context 
Gemini's safety settings are a useful feature that has no real analog in OpenAI's interface. I also personally had to deal with some errors related to the gemini safety settings when implementing Gemini for the website blocker. I was thinking about how to allow configuration of these settings in our SDK, however, there is no real analog for these settings in OpenAI. So I was thinking about supporting them using type discrimination. 

I was able to implement it successfully, but didn't feel great about the UX so I decided not to include it in my Gemini implementation. I've included my full implementation of it in this PR for reference. If you want to experiment with type discrimination. I recommend basing your changes on the implementation in this PR. 

## Options for handling SDK differences
Generally speaking, if a user tries to use a feature that is not available for a specific provider. I think we have the following options:
1. Throw an error
2. Log a warning
3. Change the SDK input format to avoid the case.
4. Use type discrimination to try to prevent the user from using the option if they select a model from a provider that does not support it. 

We also have an additional option which could make sense for some very provider specific options which is to expose fields where the provider name is in the field name so that hopefully it's obvious to the user that the feature only works with a specific provider. This would look like having an option `geminiSafetySettings` which is actually valid when you have any model selected from any provider, it just won't be used unless the provider is gemini. 

## When to throw an error
I think it makes sense to throw errors in specific cases, but I do not think we should be liberal about doing this. Throwing errors is very poor UX especially in production. 
- I think it's acceptable to do if the user attempts to use a high level feature that is not supported at all by a provider or that we do not support for that provider. I.e the user tries to use embeddings with Gemini which we have not implemented (but maybe embeddings implemented for OpenAI).
- I also think it's acceptable to do if the user configures options that would effect the structure of the model output significantly and that are not supported. For example configuring JSON output, n > 1, or function calls for providers that do not support them. 

## When to log a warning
I think it makes sense to log warnings if the user attempts to use options that don't have any specific analog in the provider they are using. For example, if we had a safety setting option which maps to Gemini, and perhaps other providers, but where OpenAI does not have any analog. I think it makes sense to log a warning that the option does not apply for OpenAI. I would do this to support many esoteric settings such as priority penalties without causing a huge UX burden.

## When to change the SDK format
I think it's reasonable to want to change the SDK format when the impact of the user doing something incompatable with a specific provider is more significant than conveyed by a warning, but that doesn't rise to the level of the cases I described in the error section above. I think the case Sam pointed out about Anthorpic requiring system messages is a good example of this. 

I've also generally been moving more towards being of the opinion that we shouldn't try to be totally compatible with OpenAI's format. I think we should try to be similar such that it's easy to onboard, but outside of that I think we should design the SDK to deliver well on portability between different providers. I think meaningful part of that is having a prompt format that works well for the majority of providers even if some allow more flexibility than others. 

That all being said, I don't think we should just immediately jump to modifying the SDK format to make a specific provider work better. I think we should make thoughtful decisions about what the best format would be for the most providers. We may encounter cases where modifying the SDK format would allow us to better support a specific provider, but that makes a significant sacrifice for all other providers. I would be very cautious about doing that. I'm not sure exactly where the anthropic case falls in this spectrum, but at first glance it seems to be worth doing because Anthropic is popular and the tradeoff for other providers seems minimal.

## Type discrimination
After a pretty significant amount of thought, I actually do not think we should use type discrimination at all unless we get feedback from users that the above solutions are not sufficient. I think the UX is counterintuitivaly very poor. My opinion on that is heavily based on the fact that a primary design goal of the SDK is to allow for switching between providers easily. If you have to deal with resolving a bunch of type errors to be able to switch, that really defeats the purpose to me. 