### PR TITLE
feat: Provide user facing types

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,31 +23,31 @@ ANTHROPIC_API_KEY=<your api>
 
 ### Usage
 ```ts
-import { LLM } from 'llmjs';
+import { LLM, ChatCompletionMessageParam } from 'llmjs';
 
 const llm = new LLM()
 
-const messages = [{
+const messages: ChatCompletionMessageParam[] = [{
   role: 'user',
   content: `How are you?`
 }]
 
 // Call OpenAI
-const result = await llm.chat.completions.create({
+const result: ChatCompletionMessageParam[] = await llm.chat.completions.create({
   provider: 'openai',
   model: 'gpt-4o',
   messages,
 })
 
 // Call Gemini
-const result = await llm.chat.completions.create({
+const result: ChatCompletionMessageParam[] = await llm.chat.completions.create({
   provider: 'gemini',
   model: 'gemini-1.5-pro',
   messages,
 })
 
 // Call Anthropic
-const result = await llm.chat.completions.create({
+const result: ChatCompletionMessageParam[] = await llm.chat.completions.create({
   provider: 'anthropic',
   model: 'claude-2.0',
   messages,
@@ -93,6 +93,8 @@ Then you can select the `provider` and `model` you would like to use when callin
 LLM.js supports streaming for all providers that support it. 
 
 ```ts
+import { LLM } from 'llmjs';
+
 const llm = new LLM()
 const result = await llm.chat.completions.create({
   stream: true,
@@ -113,9 +115,11 @@ for await (const part of result) {
 LLM.js supports tools for all providers and models that support it.
 
 ```ts
+import { LLM, ChatCompletionTool } from 'llmjs';
+
 const llm = new LLM()
 
-const tools = [{
+const tools: ChatCompletionTool[] = [{
   type: "function",
   function: {
     name: "getCurrentWeather",

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1,6 +1,5 @@
 import { ChatCompletionCreateParamsBase } from 'openai/resources/chat/completions.mjs';
 import { getHandler } from '../handlers/utils';
-import { CompletionResponse, ConfigOptions, StreamCompletionResponse } from '../handlers/types';
 import { models } from '../models';
 
 export type OpenAIModel = (typeof models.openai.models)[number];
@@ -12,6 +11,7 @@ export type BedrockModel = (typeof models.bedrock.models)[number];
 export type MistralModel = (typeof models.mistral.models)[number];
 export type PerplexityModel = (typeof models.perplexity.models)[number];
 export type GroqModel = (typeof models.groq.models)[number];
+import { CompletionResponse, StreamCompletionResponse, ConfigOptions } from "../userTypes";
 
 export type LLMChatModel = OpenAIModel | AI21Model | AnthropicModel | GeminiModel | CohereModel | BedrockModel | MistralModel | PerplexityModel | GroqModel;
 

--- a/src/handlers/ai21.ts
+++ b/src/handlers/ai21.ts
@@ -1,9 +1,10 @@
 import axios from "axios";
 import { AI21Model, CompletionParams, LLMChatModel, ProviderCompletionParams } from "../chat";
-import { CompletionResponse, InputError, StreamCompletionResponse } from "./types";
+import { InputError } from "./types";
 import { getTimestamp } from "./utils";
 import { IncomingMessage } from 'http';
 import { BaseHandler } from "./base";
+import { CompletionResponse, StreamCompletionResponse } from "../userTypes";
 
 type AI21ChatCompletionParams = {
   model: string;

--- a/src/handlers/anthropic.ts
+++ b/src/handlers/anthropic.ts
@@ -1,4 +1,4 @@
-import { CompletionResponse, InputError, StreamCompletionResponse, CompletionResponseChunk, InvariantError } from "./types";
+import { InputError, InvariantError } from "./types";
 import Anthropic from "@anthropic-ai/sdk";
 import { MessageCreateParamsNonStreaming, MessageCreateParamsStreaming, ContentBlock, Message, MessageStream, TextBlock, ToolUseBlock, TextBlockParam, ImageBlockParam, ToolUseBlockParam, ToolResultBlockParam } from "@anthropic-ai/sdk/resources/messages.mjs";
 import { consoleWarn, fetchThenParseImage, getTimestamp, isEmptyObject } from "./utils";
@@ -6,6 +6,7 @@ import { AnthropicModel, CompletionParams, ProviderCompletionParams } from "../c
 import * as dotenv from 'dotenv'
 import { ChatCompletionMessageToolCall } from "openai/resources/index.mjs";
 import { BaseHandler } from "./base";
+import { CompletionResponse, StreamCompletionResponse, CompletionResponseChunk } from "../userTypes";
 
 dotenv.config()
 

--- a/src/handlers/base.ts
+++ b/src/handlers/base.ts
@@ -1,5 +1,6 @@
 import { CompletionParams, LLMChatModel } from "../chat";
-import { CompletionResponse, ConfigOptions, InputError, StreamCompletionResponse } from "./types";
+import { InputError } from "./types";
+import { CompletionResponse, StreamCompletionResponse, ConfigOptions } from "../userTypes";
 
 export abstract class BaseHandler<T extends LLMChatModel> {
   opts: ConfigOptions;

--- a/src/handlers/bedrock.ts
+++ b/src/handlers/bedrock.ts
@@ -1,9 +1,10 @@
 import { BedrockRuntimeClient, ContentBlock, ContentBlockDelta, ConverseCommand, ConverseCommandInput, ConverseResponse, ConverseStreamCommand, ConverseStreamCommandOutput, ImageFormat, SystemContentBlock, ToolChoice } from "@aws-sdk/client-bedrock-runtime";
 import { BedrockModel, CompletionNonStreaming, CompletionParams, CompletionStreaming, ProviderCompletionParams } from "../chat";
-import {  CompletionResponse, CompletionResponseChunk, InputError, InvariantError, MIMEType, StreamCompletionResponse } from "./types";
+import { InputError, InvariantError, MIMEType } from "./types";
 import { consoleWarn, fetchThenParseImage, getTimestamp, normalizeTemperature } from "./utils";
 import { ChatCompletionMessageToolCall } from "openai/resources/index.mjs";
 import { BaseHandler } from "./base";
+import { CompletionResponse, CompletionResponseChunk, StreamCompletionResponse } from "../userTypes";
 
 
 const normalizeMIMEType = (

--- a/src/handlers/cohere.ts
+++ b/src/handlers/cohere.ts
@@ -1,12 +1,13 @@
 import { ApiMetaBilledUnits, ChatRequest, FinishReason, Message, StreamedChatResponse, Tool, ToolResult } from "cohere-ai/api";
 import { CohereModel, CompletionParams, ProviderCompletionParams } from "../chat";
-import { CompletionResponse, InputError, InvariantError, MessageRole, StreamCompletionResponse } from "./types";
+import { InputError, InvariantError, MessageRole } from "./types";
 import { consoleWarn, getTimestamp } from "./utils";
 import { ChatCompletionAssistantMessageParam, ChatCompletionMessageToolCall, ChatCompletionToolMessageParam } from "openai/resources/index.mjs";
 import { CohereClient } from "cohere-ai";
 import { Stream } from "cohere-ai/core";
 import { BaseHandler } from "./base";
 import { ChatCompletionTool } from "openai/src/resources/index.js";
+import { CompletionResponse, StreamCompletionResponse } from "../userTypes";
 
 type CohereMessageRole = "CHATBOT" | "SYSTEM" | "USER" | "TOOL"
 

--- a/src/handlers/gemini.ts
+++ b/src/handlers/gemini.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
 import { ChatCompletionChunk, ChatCompletionContentPart } from "openai/resources/index.mjs";
-import { CompletionResponse, InputError, StreamCompletionResponse } from "./types";
+import { InputError } from "./types";
 import { 
   GoogleGenerativeAI, 
   Content,
@@ -22,6 +22,7 @@ import { consoleWarn, getTimestamp, parseImage } from "./utils";
 import { CompletionParams, GeminiModel, ProviderCompletionParams } from "../chat";
 import { BaseHandler } from "./base";
 import { ChatCompletionMessageToolCall } from "openai/src/resources/index.js";
+import { CompletionResponse, StreamCompletionResponse } from "../userTypes";
 
 export const convertContentsToParts = (
   contents: Array<ChatCompletionContentPart> | string | null | undefined,

--- a/src/handlers/groq.ts
+++ b/src/handlers/groq.ts
@@ -1,8 +1,9 @@
 import Groq from "groq-sdk";
-import { CompletionResponse, InputError, StreamCompletionResponse } from "./types";
+import { InputError } from "./types";
 import { CompletionParams, GroqModel, ProviderCompletionParams } from "../chat";
 import { assertNIsOne } from "./utils";
 import { BaseHandler } from "./base";
+import { CompletionResponse, CompletionResponseChunk, StreamCompletionResponse } from "../userTypes";
 
 // Groq is very compatible with OpenAI's API, so we could likely reuse the OpenAI SDK for this handler
 // to reducee the bundle size.

--- a/src/handlers/mistral.ts
+++ b/src/handlers/mistral.ts
@@ -1,9 +1,10 @@
 import MistralClient, { ChatCompletionResponse, ChatCompletionResponseChoice, ChatCompletionResponseChunk, ChatRequest, Message, ResponseFormat, ToolCalls } from "@mistralai/mistralai";
 import { CompletionParams, MistralModel, ProviderCompletionParams } from "../chat";
-import { CompletionResponse, InputError, StreamCompletionResponse } from "./types";
+import { InputError } from "./types";
 import { ChatCompletionChunk, ChatCompletionMessage, ChatCompletionMessageParam, ChatCompletionMessageToolCall } from "openai/resources/index.mjs";
 import { ChatCompletionContentPartText } from "openai/src/resources/index.js";
 import { BaseHandler } from "./base";
+import { CompletionResponse, CompletionResponseChunk, StreamCompletionResponse } from "../userTypes";
 
 export const findLinkedToolCallName = (messages: ChatCompletionMessage[], toolCallId: string): string => {
   for (const message of messages) {

--- a/src/handlers/openai.ts
+++ b/src/handlers/openai.ts
@@ -1,9 +1,9 @@
 import OpenAI from "openai";
 import { Stream } from "openai/streaming.mjs";
-import { CompletionResponse, StreamCompletionResponse } from "./types";
 import { CompletionParams, OpenAIModel, ProviderCompletionParams } from "../chat";
 import { BaseHandler } from "./base";
 import { ChatCompletionCreateParams } from "openai/resources/index.mjs";
+import { CompletionResponse, CompletionResponseChunk, StreamCompletionResponse } from "../userTypes";
 
 async function* streamOpenAI(
   response: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>

--- a/src/handlers/perplexity.ts
+++ b/src/handlers/perplexity.ts
@@ -1,8 +1,9 @@
 import OpenAI from "openai";
 import { Stream } from "openai/streaming.mjs";
-import { CompletionResponse, InputError, StreamCompletionResponse } from "./types";
+import { InputError } from "./types";
 import { PerplexityModel, ProviderCompletionParams } from "../chat";
 import { BaseHandler } from "./base";
+import { CompletionResponse, CompletionResponseChunk, StreamCompletionResponse } from "../userTypes";
 
 export const PERPLEXITY_PREFIX = "perplexity/";
 

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -1,39 +1,5 @@
-import { ClientOptions } from "openai";
-import { ChatCompletionChunk, ChatModel } from "openai/resources/index.mjs";
-import { CompletionParams } from "../chat";
-import { ChatCompletion } from "openai/src/resources/index.js";
-import { models } from "../models";
-
 export type MessageRole = 'system' | 'user' | 'assistant' | 'tool' | 'function'
-
-export type ConfigOptions = Pick<ClientOptions, 'apiKey' | 'baseURL'> & {
-  bedrock?: {
-    region?: string
-    accessKeyId?: string
-    secretAccessKey?: string
-  }
-}
-
-export type ChatCompletionChoice = Omit<ChatCompletion.Choice, 'finish_reason'> & {
-  finish_reason: ChatCompletion.Choice['finish_reason'] | 'unknown'
-}
-
-type ChatCompletionChunkChoice = Omit<ChatCompletionChunk.Choice, 'finish_reason'> & {
-  finish_reason: ChatCompletionChunk.Choice['finish_reason'] | 'unknown'
-}
-
 export type MIMEType = "image/jpeg" | "image/png" | "image/gif" | "image/webp"
-
-export type CompletionResponseFields = 'created' | 'model' | 'usage' | 'object'
-export type CompletionResponse = Pick<ChatCompletion, CompletionResponseFields> & {
-  id: string | null
-  choices: Array<ChatCompletionChoice>
-}
-export type CompletionResponseChunk = Pick<ChatCompletionChunk, CompletionResponseFields>  & {
-  id: string | null
-  choices: Array<ChatCompletionChunkChoice>
-}
-export type StreamCompletionResponse = AsyncIterable<CompletionResponseChunk>
 
 export class InputError extends Error {
   constructor(message: string) {

--- a/src/handlers/utils.ts
+++ b/src/handlers/utils.ts
@@ -2,7 +2,7 @@ import { AnthropicHandler } from "./anthropic";
 import { GeminiHandler } from "./gemini";
 import { MistralHandler } from "./mistral";
 import { OpenAIHandler } from "./openai";
-import { ConfigOptions, InputError, MIMEType } from "./types";
+import { InputError, MIMEType } from "./types";
 import { BaseHandler } from "./base";
 import chalk from 'chalk'
 import { CohereHandler } from "./cohere";
@@ -13,6 +13,7 @@ import { AI21Handler } from "./ai21";
 import { PerplexityHandler } from "./perplexity";
 import { models } from "../models";
 import { LLMChatModel, LLMProvider } from "../chat";
+import { ConfigOptions } from "../userTypes";
 
 export const Handlers: Record<string, (opts: ConfigOptions) => any> = {
   ['openai']: (opts: ConfigOptions) => new OpenAIHandler(opts, models.openai.models, models.openai.supportsJSON),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import OpenAI, { ClientOptions } from 'openai';
 import { LLMChat } from './chat';
-import { ConfigOptions } from './handlers/types';
+import { ConfigOptions } from "./userTypes";
+export * from './userTypes'
 
 // Extract the public interface from OpenAI, including both properties and methods
 type PublicInterface<T> = {

--- a/src/userTypes/index.ts
+++ b/src/userTypes/index.ts
@@ -1,0 +1,52 @@
+/**
+ * These types are explicitly intended to be imported by the user. We keep them separate for clarity
+ * and so that they can be easily imported and used alongside the primary LLM class.
+ */
+import { ClientOptions } from 'openai'
+import {
+  ChatCompletion,
+  ChatCompletionChunk,
+  ChatCompletionTool as OpenAIChatCompletionTool,
+  ChatCompletionMessageParam as OpenAICompletionMessageParam,
+} from 'openai/resources/index.mjs'
+
+export type ConfigOptions = Pick<ClientOptions, 'apiKey' | 'baseURL'> & {
+  bedrock?: {
+    region?: string
+    accessKeyId?: string
+    secretAccessKey?: string
+  }
+}
+
+export type ChatCompletionChoice = Omit<
+  ChatCompletion.Choice,
+  'finish_reason'
+> & {
+  finish_reason: ChatCompletion.Choice['finish_reason'] | 'unknown'
+}
+
+export type ChatCompletionChunkChoice = Omit<
+  ChatCompletionChunk.Choice,
+  'finish_reason'
+> & {
+  finish_reason: ChatCompletionChunk.Choice['finish_reason'] | 'unknown'
+}
+
+type CompletionResponseFields = 'created' | 'model' | 'usage' | 'object'
+export type CompletionResponse = Pick<
+  ChatCompletion,
+  CompletionResponseFields
+> & {
+  id: string | null
+  choices: Array<ChatCompletionChoice>
+}
+export type CompletionResponseChunk = Pick<
+  ChatCompletionChunk,
+  CompletionResponseFields
+> & {
+  id: string | null
+  choices: Array<ChatCompletionChunkChoice>
+}
+export type StreamCompletionResponse = AsyncIterable<CompletionResponseChunk>
+export type ChatCompletionMessageParam = OpenAICompletionMessageParam
+export type ChatCompletionTool = OpenAIChatCompletionTool

--- a/test/handlers/gemini.test.ts
+++ b/test/handlers/gemini.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { GeminiHandler, convertAssistantMessage, convertContentsToParts, convertFinishReason, convertMessageToContent, convertMessagesToContents, convertResponse, convertResponseMessage, convertRole, convertStreamToolCalls, convertToolCalls, convertToolConfig, convertTools, convertUsageData } from '../../src/handlers/gemini';
 import { ChatCompletionContentPart } from 'openai/resources/index.mjs';
-import { InputError, StreamCompletionResponse } from '../../src/handlers/types';
+import { InputError } from '../../src/handlers/types';
 import OpenAI from 'openai';
 import { EnhancedGenerateContentResponse, FinishReason, FunctionCallingMode, GenerateContentCandidate, GenerateContentResult, GenerateContentStreamResult, GoogleGenerativeAI, HarmCategory, HarmProbability, UsageMetadata } from '@google/generative-ai';
 import { CompletionParams } from '../../src/chat';
 import { models } from '../../src/models';
 import { getTimestamp } from '../../src/handlers/utils';
+import { StreamCompletionResponse } from '../../src/userTypes';
 
 // Unit Tests
 describe('convertContentsToParts', () => {
@@ -1140,6 +1141,7 @@ const mockChatStreamResponse: GenerateContentStreamResult = {
 const model = 'gemini-1.5-pro';
 
 const toolPrompt: CompletionParams = {
+  provider: 'gemini',
   model,
   messages: [
     {
@@ -1205,6 +1207,7 @@ describe('GeminiHandler', () => {
     }));
 
     const params: CompletionParams = {
+      provider: 'gemini',
       model,
       messages: [
         {

--- a/test/handlers/mistral.test.ts
+++ b/test/handlers/mistral.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ChatCompletionMessage, ChatCompletionToolChoiceOption } from 'openai/resources/index.mjs'; // Adjust this path as needed
 import { ChatCompletionMessageParam } from 'openai/src/resources/index.js';
 import { MistralHandler, convertMessages, convertStreamToolCalls, convertToolCalls, convertToolConfig, convertTools, findLinkedToolCallName } from '../../src/handlers/mistral';
-import { InputError, StreamCompletionResponse } from '../../src/handlers/types';
+import { InputError } from '../../src/handlers/types';
 import { CompletionParams } from '../../src/chat';
 import MistralClient, { ChatCompletionResponse, ChatCompletionResponseChunk, ToolCalls } from '@mistralai/mistralai';
 import * as mistral from '@mistralai/mistralai';
 import { models } from '../../src/models';
+import { StreamCompletionResponse } from '../../src/userTypes';
 
 describe('findLinkedToolCallName', () => {
   it('should return the correct function name for a given tool call ID', () => {
@@ -664,7 +665,8 @@ describe('MistralHandler', () => {
   }));
 
   const toolPrompt: CompletionParams = {
-    model: 'mistral/mistral-large-2402',
+    provider: 'mistral',
+    model: 'mistral-large-2402',
     messages: [
       {
         role: 'user',
@@ -702,7 +704,8 @@ describe('MistralHandler', () => {
     }));
 
     const params: CompletionParams = {
-      model: 'mistral/open-mistral-7b',
+      provider: 'mistral',
+      model: 'open-mistral-7b',
       messages: [
         {
           role: 'user',


### PR DESCRIPTION
## Purpose
- Fixes some issues with the tests related to switching to separate provider and model fields
- Moves some of the types into a special `./userTypes` file which are exported for use by the user
- Reexports some useful OpenAI types from the `./userTypes` to simplify implementation (it's a bit cleaner to just import everything from us instead of importing from both us and openai, however it is not required. You can still use the OpenAI types themselves)