### PR TITLE
✨ Option to use an unlisted model

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,31 @@ async function main() {
 main()
 ```
 
+### Using an Unlisted Model
+
+If you need to use a model that's not in Token.js's predefined list (such as a fine-tuned model or a newly released one), you can use the `byPassModelCheck` option:
+
+```ts
+// Initialize with model check bypassed
+const tokenjs = new TokenJS({
+  byPassModelCheck: true
+})
+
+// Now you can use any model name
+await tokenjs.chat.completions.create({
+  provider: 'bedrock',
+  model: 'us.anthropic.claude-3-sonnet', // Would normally throw an error if unlisted
+  messages: [
+    { role: 'user', content: 'Hello!' }
+  ]
+})
+```
+
+When using TypeScript, you may need to cast unlisted model names:
+```ts
+model: 'your-custom-model' as any
+```
+
 ### Access Credentials
 
 We recommend using environment variables to configure the credentials for each LLM provider.

--- a/src/handlers/base.ts
+++ b/src/handlers/base.ts
@@ -154,7 +154,7 @@ export abstract class BaseHandler<T extends LLMChatModel> {
   // We make this public so that we can mock it in tests, which is fine because the `BaseHandler`
   // class isn't exposed to the user.
   public isSupportedModel(model: string): model is T {
-    return this.isSupportedFeature(this.models, model as T)
+    return this.opts.byPassModelCheck || this.isSupportedFeature(this.models, model as T)
   }
 
   protected supportsJSONMode(model: T): boolean {

--- a/src/userTypes/index.ts
+++ b/src/userTypes/index.ts
@@ -11,6 +11,26 @@ import {
 } from 'openai/resources/index'
 
 export type ConfigOptions = Pick<ClientOptions, 'apiKey' | 'baseURL'> & {
+  /**
+   * When set to true, skips validation of model names. This is useful when using models that are not
+   * in the predefined list, such as fine-tuned models or models from providers that frequently add new ones.
+   *
+   * @example
+   * // Initialize with model check bypassed
+   * const tokenjs = new TokenJS({
+   *   byPassModelCheck: true
+   * })
+   *
+   * // Now you can use any model name
+   * await tokenjs.chat.completions.create({
+   *   provider: 'bedrock',
+   *   model: 'us.anthropic.claude-3-sonnet', // Would normally throw an error if unlisted
+   *   messages: [
+   *     { role: 'user', content: 'Hello!' }
+   *   ]
+   * })
+   */
+  byPassModelCheck?: boolean,
   bedrock?: {
     region?: string
     accessKeyId?: string


### PR DESCRIPTION
added 'byPassModelCheck' option to use an unlisted model without token.js throwing an error