### PR TITLE
✨ Method to use other model names

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,44 @@ async function main() {
 main()
 ```
 
+### Extending Model Support
+
+Token.js allows you to extend the predefined model list using the `extendModelList` method. Here are some example scenarios where this is useful:
+1. Adding AWS Bedrock models with regional prefixes like `us.anthropic.claude-3-sonnet`
+2. Supporting new model versions like `gpt-4-1106-preview` before they're added to the predefined list
+3. Using custom model deployments with unique names
+4. Adding experimental or beta models during testing
+
+```ts
+import { TokenJS } from 'token.js'
+
+// Example from main.ts - Adding AWS Bedrock Claude models with region prefix
+// Note: 'as any' must be used here since the model name is not in the predefined list
+const tokenjs = new TokenJS().extendModelList(
+  "bedrock",
+  'us.anthropic.claude-3-5-sonnet-20241022-v2:0' as any,
+  "anthropic.claude-3-sonnet-20240229-v1:0" // Copy features from existing model
+);
+
+console.log(TokenJS.extendedModelList);
+// TokenJS.extendedModelList will contain:
+// [{
+//   provider: "bedrock",
+//   name: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+//   featureSupport: "anthropic.claude-3-sonnet-20240229-v1:0"
+// }]
+```
+
+The `featureSupport` parameter can be either:
+- A string matching an existing model name from the same provider to copy its feature support
+- An object specifying which features the model supports:
+  | Feature    | Type    | Description                                  |
+  |------------|---------|----------------------------------------------|
+  | streaming  | boolean | Whether the model supports streaming responses|
+  | json       | boolean | Whether the model supports JSON mode         |
+  | toolCalls  | boolean | Whether the model supports function calling  |
+  | images     | boolean | Whether the model supports image inputs      |
+
 ## Feature Compatibility
 
 This table provides an overview of the features that Token.js supports from each LLM provider.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { LLMChat } from './chat/index.js'
+import { LLMChat, LLMProvider } from './chat/index.js'
+import { models } from './models.js'
 import { ConfigOptions } from './userTypes/index.js'
 export * from './userTypes/index.js'
 
@@ -20,10 +21,35 @@ export * from './userTypes/index.js'
 
 type TokenJSInterface = {
   chat: LLMChat
+  extendModelList<
+    P extends Exclude<LLMProvider, 'openrouter' | 'openai-compatible'>
+  >(
+    provider: P,
+    name: string,
+    featureSupport: extendedModelFeatureSupport<P>
+  ): void
 }
+
+export type extendedModelFeatureSupport<P extends LLMProvider> =
+  | ((typeof models)[P]['models'] extends readonly string[]
+      ? (typeof models)[P]['models'][number]
+      : never)
+  | {
+      streaming: boolean
+      json: boolean
+      toolCalls: boolean
+      images: boolean
+    }
+
+type extendedModelList = Array<{
+  provider: LLMProvider
+  name: string
+  featureSupport: extendedModelFeatureSupport<any>
+}>
 
 export class TokenJS implements TokenJSInterface {
   private opts: ConfigOptions
+  public static extendedModelList: Readonly<extendedModelList> = []
   chat: LLMChat
 
   constructor({ ...opts }: ConfigOptions = {}) {
@@ -31,5 +57,113 @@ export class TokenJS implements TokenJSInterface {
 
     // We pass a reference to the LLM instance to the LLMChat instance so that the completions object can access the opts
     this.chat = new LLMChat(opts)
+  }
+
+  /**
+   * Checks if a model exists in the extended model list for a given provider
+   *
+   * @param provider - The LLM provider to check
+   * @param name - The model name to check
+   * @returns boolean indicating if the model exists
+   */
+  extendedModelExist<
+    P extends Exclude<LLMProvider, 'openrouter' | 'openai-compatible'>
+  >(provider: P, name: string): boolean {
+    return TokenJS.extendedModelList.some(
+      (model) => model.provider === provider && model.name === name
+    )
+  }
+
+  /**
+   * Extends the predefined model list by adding a new model with specified features.
+   *
+   * @param provider - The LLM provider (e.g., 'bedrock', 'openai')
+   * @param name - The model name/identifier to add
+   * @param featureSupport - Either:
+   *- A string matching an existing model name from the same provider to copy its feature support
+   *- An object specifying which features the model supports:
+   *| Feature    | Type    | Description                                  |
+   *|------------|---------|----------------------------------------------|
+   *| streaming  | boolean | Whether the model supports streaming responses|
+   *| json       | boolean | Whether the model supports JSON mode         |
+   *| toolCalls  | boolean | Whether the model supports function calling  |
+   *| images     | boolean | Whether the model supports image inputs      |
+   * @returns The TokenJS instance for chaining
+   *
+   * @example
+   * ```typescript
+   * // Example from main.ts - Adding AWS Bedrock Claude models with region prefix
+   * // Note: 'as any' must be used here since the model name is not in the predefined list
+   * const tokenjs = new TokenJS().extendModelList(
+   *   "bedrock",
+   *   'us.anthropic.claude-3-5-sonnet-20241022-v2:0' as any,
+   *   "anthropic.claude-3-sonnet-20240229-v1:0" // Copy features from existing model
+   * );
+   *
+   * console.log(TokenJS.extendedModelList);
+   * // TokenJS.extendedModelList will contain:
+   * // [{
+   * //   provider: "bedrock",
+   * //   name: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+   * //   featureSupport: "anthropic.claude-3-sonnet-20240229-v1:0"
+   * // }]
+   * ```
+   */
+  extendModelList<
+    P extends Exclude<LLMProvider, 'openrouter' | 'openai-compatible'>
+  >(provider: P, name: string, featureSupport: extendedModelFeatureSupport<P>) {
+    // Do nothing if the model already added in the extendedModeList
+    if (this.extendedModelExist(provider, name)) {
+      return this
+    }
+
+    const modelsRef = models[provider] as any
+    modelsRef['models'] = [...(models as any)[provider]['models'], name]
+
+    const isSupportedFeature = (
+      _featureSupport: readonly string[] | boolean,
+      model: string
+    ) => {
+      if (typeof _featureSupport === 'boolean') {
+        return _featureSupport
+      }
+      return _featureSupport.includes(model)
+    }
+
+    if (typeof featureSupport == 'string') {
+      // Copy feature support from existing model
+      if (isSupportedFeature(modelsRef.supportsJSON, featureSupport)) {
+        modelsRef['supportsJSON'] = [...modelsRef.supportsJSON, name]
+      }
+      if (isSupportedFeature(modelsRef.supportsStreaming, featureSupport)) {
+        modelsRef['supportsStreaming'] = [...modelsRef.supportsStreaming, name]
+      }
+      if (isSupportedFeature(modelsRef.supportsImages, featureSupport)) {
+        modelsRef['supportsImages'] = [...modelsRef.supportsImages, name]
+      }
+      if (isSupportedFeature(modelsRef.supportsToolCalls, featureSupport)) {
+        modelsRef['supportsToolCalls'] = [...modelsRef.supportsToolCalls, name]
+      }
+    } else {
+      // Use explicit feature support object
+      if (featureSupport.json) {
+        modelsRef['supportsJSON'] = [...modelsRef.supportsJSON, name]
+      }
+      if (featureSupport.streaming) {
+        modelsRef['supportsStreaming'] = [...modelsRef.supportsStreaming, name]
+      }
+      if (featureSupport.toolCalls) {
+        modelsRef['supportsToolCalls'] = [...modelsRef.supportsToolCalls, name]
+      }
+      if (featureSupport.images) {
+        modelsRef['supportsImages'] = [...modelsRef.supportsImages, name]
+      }
+    }
+    ;(TokenJS.extendedModelList as extendedModelList).push({
+      provider,
+      name,
+      featureSupport,
+    })
+    return this
   }
 }


### PR DESCRIPTION
method to add a model name for a given provider if the pre-defined list is not enough. I used any a lot in the method to bypass const and avoid refactoring and moving too much code