### PR TITLE
Use the correct pnpm across the board

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 8.6.12
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 8.6.12
     - name: Use Node.js 20
       uses: actions/setup-node@v4
       with:
@@ -30,7 +30,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 8.6.12
     - name: Use Node.js 20
       uses: actions/setup-node@v4
       with:
@@ -47,7 +47,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 8.6.12
     - name: Use Node.js 20
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 8.6.12
     - name: Use Node.js 20
       uses: actions/setup-node@v4
       with:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/token-js/token.js"
   },
+  "packageManager": "pnpm@8.6.12",
   "description": "Integrate 9 LLM providers with a single Typescript SDK using OpenAIs format.",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Closes https://github.com/token-js/token.js/issues/166

This ensures that the correct pnpm version is used locally and in github actions. 