### PR TITLE
Add gemini 2.5 pro and flash models

### DIFF
--- a/.changeset/cold-planets-confess.md
+++ b/.changeset/cold-planets-confess.md
@@ -1,0 +1,5 @@
+---
+'token.js': patch
+---
+
+Add gemini 2.5 pro and flash preview models

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -46,6 +46,8 @@ main()
 | gemini-1.5-flash                    | ✅               | ✅         | ✅           | ✅           | ✅                | ✅     |
 | gemini-1.5-flash-8b                 | ✅               | ✅         | ✅           | ✅           | ✅                | ✅     |
 | gemini-1.0-pro                      | ✅               | ✅         | ➖           | ➖           | ✅                | ✅     |
+| gemini-2.5-flash-preview-04-17      | ✅               | ✅         | ✅           | ✅           | ✅                | ✅     |
+| gemini-2.5-pro-preview-03-25        | ✅               | ✅         | ✅           | ✅           | ✅                | ✅     |
 
 ### Legend
 | Symbol             | Description                           |

--- a/src/models.ts
+++ b/src/models.ts
@@ -205,6 +205,8 @@ export const models = {
       'gemini-1.5-flash',
       'gemini-1.5-flash-8b',
       'gemini-1.0-pro',
+      'gemini-2.5-flash-preview-04-17',
+      'gemini-2.5-pro-preview-03-25',
     ] as const,
     supportsCompletion: true,
     supportsStreaming: [
@@ -214,6 +216,8 @@ export const models = {
       'gemini-1.5-flash',
       'gemini-1.5-flash-8b',
       'gemini-1.0-pro',
+      'gemini-2.5-flash-preview-04-17',
+      'gemini-2.5-pro-preview-03-25',
     ] as const,
     supportsJSON: [
       'gemini-2.0-flash-001',
@@ -221,6 +225,8 @@ export const models = {
       'gemini-1.5-pro',
       'gemini-1.5-flash',
       'gemini-1.5-flash-8b',
+      'gemini-2.5-flash-preview-04-17',
+      'gemini-2.5-pro-preview-03-25',
     ] as const,
     supportsImages: [
       'gemini-2.0-flash-001',
@@ -228,6 +234,8 @@ export const models = {
       'gemini-1.5-pro',
       'gemini-1.5-flash',
       'gemini-1.5-flash-8b',
+      'gemini-2.5-flash-preview-04-17',
+      'gemini-2.5-pro-preview-03-25',
     ] as const,
     supportsToolCalls: [
       'gemini-2.0-flash-001',
@@ -235,6 +243,8 @@ export const models = {
       'gemini-1.5-flash',
       'gemini-1.5-flash-8b',
       'gemini-1.0-pro',
+      'gemini-2.5-flash-preview-04-17',
+      'gemini-2.5-pro-preview-03-25',
     ] as const,
     supportsN: true,
     generateDocs: true,


### PR DESCRIPTION
A### All Submissions (required):

* [x] Have you read the [Contributing](https://github.com/token-js/token.js/blob/main/CONTRIBUTING.md) guidelines?
* [x] Have you updated the documentation with `pnpm docs`?
* [x] Have you ran the linter with `pnpm lint:fix`?
* [x] Have you successfully ran the tests locally with `pnpm test`?
* [x] Have you added a changeset file with `pnpm changeset`?
* [x] Please link any relevant GitHub issue here.

What: As titled
Why: To support new versions of gemini

Evidence:
<img width="1045" alt="スクリーンショット 2025-04-28 14 06 01" src="https://github.com/user-attachments/assets/28bba8d8-e3ae-4ef2-80e2-d7cfd4c4e93e" />

https://ai.google.dev/gemini-api/docs/models